### PR TITLE
fix parent version numbers on pom.xml files that are not modules in the parent pom

### DIFF
--- a/scufl2-rdf/pom.xml
+++ b/scufl2-rdf/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.org.taverna.scufl2</groupId>
 		<artifactId>scufl2</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>0.9.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>scufl2-rdf</artifactId>
 	<packaging>bundle</packaging>

--- a/scufl2-usecases/pom.xml
+++ b/scufl2-usecases/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>uk.org.taverna.scufl2</groupId>
 		<artifactId>scufl2</artifactId>
-		<version>0.9.2-SNAPSHOT</version>
+		<version>0.9.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>scufl2-usecases</artifactId>
 	<name>Taverna Scufl 2 use cases</name>

--- a/scufl2-validation-integration/pom.xml
+++ b/scufl2-validation-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>uk.org.taverna.scufl2</groupId>
     <artifactId>scufl2</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
   </parent>
   <artifactId>scufl2-validation-integration</artifactId>
   <packaging>bundle</packaging>


### PR DESCRIPTION
Two pom.xml files that needed changes to the parent pom version reference. They would not have been recognised in normal operation as they are not linked as modules in the parent pom so they don't get executed as part of the normal reactor.
